### PR TITLE
Enable passing a kubeconfig file to apiserver

### DIFF
--- a/cmd/apiserver/app/server/options.go
+++ b/cmd/apiserver/app/server/options.go
@@ -20,10 +20,11 @@ import (
 	"os"
 
 	"github.com/golang/glog"
-	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
 	"github.com/spf13/pflag"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	genericserveroptions "k8s.io/apiserver/pkg/server/options"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/registry/servicecatalog/server"
 )
 
 const (
@@ -59,6 +60,8 @@ type ServiceCatalogServerOptions struct {
 	StandaloneMode bool
 	// whether or not to serve the OpenAPI spec (at /swagger.json)
 	ServeOpenAPISpec bool
+	// KubeconfigPath, if specified, is used over the in-cluster service account token.
+	KubeconfigPath string
 }
 
 // NewServiceCatalogServerOptions creates a new instances of
@@ -102,6 +105,12 @@ func (s *ServiceCatalogServerOptions) AddFlags(flags *pflag.FlagSet) {
 		"serve-openapi-spec",
 		false,
 		"Whether this API server should serve the OpenAPI spec (problematic with older versions of kubectl)",
+	)
+	flags.StringVar(
+		&s.KubeconfigPath,
+		"kubeconfig",
+		"",
+		"Path to kubeconfig to use over the in-cluster service account token",
 	)
 
 	s.GenericServerRunOptions.AddUniversalFlags(flags)

--- a/cmd/apiserver/app/server/util.go
+++ b/cmd/apiserver/app/server/util.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/initializer"
 	admissionmetrics "k8s.io/apiserver/pkg/admission/metrics"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -42,8 +43,8 @@ import (
 	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/internalclientset"
 	informers "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/internalversion"
 	"github.com/kubernetes-incubator/service-catalog/pkg/openapi"
+	"github.com/kubernetes-incubator/service-catalog/pkg/svcat/kube"
 	"github.com/kubernetes-incubator/service-catalog/pkg/version"
-	"k8s.io/apiserver/pkg/admission/initializer"
 )
 
 // serviceCatalogConfig is a placeholder for configuration
@@ -61,8 +62,7 @@ type serviceCatalogConfig struct {
 // buildGenericConfig takes the server options and produces the genericapiserver.RecommendedConfig associated with it
 func buildGenericConfig(s *ServiceCatalogServerOptions) (*genericapiserver.RecommendedConfig, *serviceCatalogConfig, error) {
 	// check if we are running in standalone mode (for test scenarios)
-	inCluster := !s.StandaloneMode
-	if !inCluster {
+	if s.StandaloneMode {
 		glog.Infof("service catalog is in standalone mode")
 	}
 	// server configuration options
@@ -76,7 +76,7 @@ func buildGenericConfig(s *ServiceCatalogServerOptions) (*genericapiserver.Recom
 	if err := s.SecureServingOptions.ApplyTo(&genericConfig.Config); err != nil {
 		return nil, nil, err
 	}
-	if !s.DisableAuth && inCluster {
+	if !s.DisableAuth && !s.StandaloneMode {
 		if err := s.AuthenticationOptions.ApplyTo(&genericConfig.Config.Authentication, genericConfig.Config.SecureServing, genericConfig.Config.OpenAPIConfig); err != nil {
 			return nil, nil, err
 		}
@@ -132,15 +132,23 @@ func buildGenericConfig(s *ServiceCatalogServerOptions) (*genericapiserver.Recom
 		client:          client,
 		sharedInformers: sharedInformers,
 	}
-	if inCluster {
-		inClusterConfig, err := restclient.InClusterConfig()
+	if !s.StandaloneMode {
+		clusterConfig, err := kube.LoadConfig(s.KubeconfigPath, "")
 		if err != nil {
-			glog.Errorf("Failed to get kube client config: %v", err)
+			glog.Errorf("Failed to parse kube client config: %v", err)
 			return nil, nil, err
 		}
-		inClusterConfig.GroupVersion = &schema.GroupVersion{}
+		// If clusterConfig is nil, look at the default in-cluster config.
+		if clusterConfig == nil {
+			clusterConfig, err = restclient.InClusterConfig()
+			if err != nil {
+				glog.Errorf("Failed to get kube client config: %v", err)
+				return nil, nil, err
+			}
+		}
+		clusterConfig.GroupVersion = &schema.GroupVersion{}
 
-		kubeClient, err := kubeclientset.NewForConfig(inClusterConfig)
+		kubeClient, err := kubeclientset.NewForConfig(clusterConfig)
 		if err != nil {
 			glog.Errorf("Failed to create clientset interface: %v", err)
 			return nil, nil, err

--- a/pkg/svcat/kube/kube.go
+++ b/pkg/svcat/kube/kube.go
@@ -18,6 +18,7 @@ package kube
 
 import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Load all client auth plugins for gcp, azure, etc
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -35,4 +36,9 @@ func GetConfig(context, kubeconfig string) clientcmd.ClientConfig {
 	}
 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+}
+
+// LoadConfig return a Kubernetes client config to be used by rest clients.
+func LoadConfig(config, context string) (*rest.Config, error) {
+	return GetConfig(context, config).ClientConfig()
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
+	"github.com/kubernetes-incubator/service-catalog/pkg/svcat/kube"
 )
 
 // Framework supports common operations used by e2e tests; it will keep a client & a namespace for you.
@@ -61,14 +62,14 @@ func (f *Framework) BeforeEach() {
 	f.cleanupHandle = AddCleanupAction(f.AfterEach)
 
 	By("Creating a kubernetes client")
-	kubeConfig, err := LoadConfig(TestContext.KubeConfig, TestContext.KubeContext)
+	kubeConfig, err := kube.LoadConfig(TestContext.KubeConfig, TestContext.KubeContext)
 	Expect(err).NotTo(HaveOccurred())
 	kubeConfig.QPS = 50
 	kubeConfig.Burst = 100
 	f.KubeClientSet, err = kubernetes.NewForConfig(kubeConfig)
 	Expect(err).NotTo(HaveOccurred())
 	By("Creating a service catalog client")
-	serviceCatalogConfig, err := LoadConfig(TestContext.ServiceCatalogConfig, TestContext.ServiceCatalogContext)
+	serviceCatalogConfig, err := kube.LoadConfig(TestContext.ServiceCatalogConfig, TestContext.ServiceCatalogContext)
 	Expect(err).NotTo(HaveOccurred())
 	serviceCatalogConfig.QPS = 50
 	serviceCatalogConfig.Burst = 100

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kubernetes-incubator/service-catalog/pkg/svcat/kube"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -31,8 +32,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 const (
@@ -70,30 +69,10 @@ func Skipf(format string, args ...interface{}) {
 	Skip(nowStamp() + ": " + msg)
 }
 
-func RestclientConfig(config, context string) (*api.Config, error) {
-	Logf(">>> config: %s\n", config)
-	if config == "" {
-		return nil, fmt.Errorf("Config file must be specified to load client config")
-	}
-	c, err := clientcmd.LoadFromFile(config)
-	if err != nil {
-		return nil, fmt.Errorf("error loading config: %v", err.Error())
-	}
-	if context != "" {
-		Logf(">>> context: %s\n", context)
-		c.CurrentContext = context
-	}
-	return c, nil
-}
-
 type ClientConfigGetter func() (*rest.Config, error)
 
 func LoadConfig(config, context string) (*rest.Config, error) {
-	c, err := RestclientConfig(config, context)
-	if err != nil {
-		return nil, err
-	}
-	return clientcmd.NewDefaultClientConfig(*c, &clientcmd.ConfigOverrides{}).ClientConfig()
+	return kube.GetConfig(context, config).ClientConfig()
 }
 
 // unique identifier of the e2e run

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kubernetes-incubator/service-catalog/pkg/svcat/kube"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -70,10 +69,6 @@ func Skipf(format string, args ...interface{}) {
 }
 
 type ClientConfigGetter func() (*rest.Config, error)
-
-func LoadConfig(config, context string) (*rest.Config, error) {
-	return kube.GetConfig(context, config).ClientConfig()
-}
 
 // unique identifier of the e2e run
 var RunId = uuid.NewUUID()


### PR DESCRIPTION
Upstream cherry-pick of https://github.com/kubernetes-incubator/service-catalog/pull/2158

Also contains https://github.com/kubernetes-incubator/service-catalog/pull/2136 which we miss but on which 2158 is based on.

@jpeeler @jim-minter @pweil- 