### PR TITLE
Fix go version check

### DIFF
--- a/hack/lib/build/binaries.sh
+++ b/hack/lib/build/binaries.sh
@@ -83,12 +83,7 @@ function os::build::setup_env() {
   # a version number, so we skip this check on Travis.  It's unnecessary
   # there anyway.
   if [[ "${TRAVIS:-}" != "true" ]]; then
-    local go_version
-    go_version=($(go version))
-    if [[ "${go_version[2]}" < "${OS_REQUIRED_GO_VERSION}" ]]; then
-      os::log::fatal "Detected Go version: ${go_version[*]}.
-Builds require Go version ${OS_REQUIRED_GO_VERSION} or greater."
-    fi
+    os::golang::verify_go_version
   fi
   # For any tools that expect this to be set (it is default in golang 1.6),
   # force vendor experiment.

--- a/hack/lib/util/golang.sh
+++ b/hack/lib/util/golang.sh
@@ -2,13 +2,13 @@
 #
 # This library holds golang related utility functions.
 
-# os::golang::verify_go_version ensure the go tool exists and is a viable version.
+# os::golang::verify_go_version ensures the go tool exists and is a viable version.
 function os::golang::verify_go_version() {
 	os::util::ensure::system_binary_exists 'go'
 
 	local go_version
 	go_version=($(go version))
-	if [[ "${go_version[2]}" != go1.8* ]]; then
+	if ! echo "${go_version[2]#go}" | awk -F. -v min=${OS_REQUIRED_GO_VERSION#go} '{ exit $2 < min }'; then
 		os::log::info "Detected go version: ${go_version[*]}."
 		if [[ -z "${PERMISSIVE_GO:-}" ]]; then
 			os::log::fatal "Please install Go version ${OS_REQUIRED_GO_VERSION} or use PERMISSIVE_GO=y to bypass this check."


### PR DESCRIPTION
When trying to run a prowjob manually that tries to run `branch-ci-openshift-service-catalog-images`, I get the following error
```
2018/07/11 13:02:33 Resolved source https://github.com/openshift/service-catalog to release-3.10@f5f6c035
2018/07/11 13:02:33 Resolved https://api.ci.openshift.org/openshift/release:golang-1.10 to sha256:cfeddce041ed5ca39f531942853d6b0fbf7460f7d3edb4fbfda7ddeefedb10cd
2018/07/11 13:02:33 Resolved https://api.ci.openshift.org/openshift/origin-v3.11:base to sha256:7ae506f8ca13a7c36f9891ec7db687b9c2673fc3f008f19943b6824ff66b0bdb
2018/07/11 13:02:33 Running [input:root], [input:base-without-rpms], [release-inputs], src, bin, rpms, [serve:rpms], base, service-catalog, [output:stable:service-catalog], [images]
2018/07/11 13:02:33 Creating namespace ci-op-hln7zfvj
2018/07/11 13:02:33 Namespace will be deleted after 10m0s of idle time
2018/07/11 13:02:34 Tagging release images from openshift/origin-v3.11:${component}
2018/07/11 13:02:34 Tagging https://api.ci.openshift.org/openshift/release:golang-1.10 into pipeline:root
2018/07/11 13:02:34 Tagging https://api.ci.openshift.org/openshift/origin-v3.11:base into pipeline:base-without-rpms
2018/07/11 13:02:34 Building src
2018/07/11 13:04:05 Build src succeeded after 1m29s
2018/07/11 13:04:05 Building bin
2018/07/11 13:04:22 Build bin failed, printing logs:

Pulling image docker-registry.default.svc:5000/ci-op-hln7zfvj/pipeline@sha256:8050db31c687e5aecc77f2d53b654b19aaded5d24381091a98fa36fd23893db4 ...
Pulled 2/3 layers, 72% complete
Pulled 3/3 layers, 100% complete
Extracting
--> FROM docker-registry.default.svc:5000/ci-op-hln7zfvj/pipeline@sha256:8050db31c687e5aecc77f2d53b654b19aaded5d24381091a98fa36fd23893db4 as 0
--> RUN ["/bin/bash","-c","set -o errexit; umask 0002; make build"]
hack/build-go.sh  
[FATAL] Detected Go version: go version go1.10.3 linux/amd64.
[FATAL] Builds require Go version go1.8 or greater.
[ERROR] PID 14: hack/lib/build/binaries.sh:155: `local -a binaries=("$@")` exited with status 1.
```

The version comparison breaks because it's a mere string comparison. This PR mirrors what happens in openshift/origin.

/cc @jpeeler 