### PR TITLE
Service catalog is not ready to be in the release payload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,3 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/kubernetes-incubator/service-catalog/_output/local/bin/linux/amd64/service-catalog /usr/bin/
 COPY manifests /manifests/
 CMD ["/usr/bin/service-catalog"]
-LABEL io.openshift.release.operator=true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,4 +7,3 @@ FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/kubernetes-incubator/service-catalog/_output/local/bin/linux/amd64/service-catalog /usr/bin/
 COPY manifests /manifests/
 CMD ["/usr/bin/service-catalog"]
-LABEL io.openshift.release.operator=true


### PR DESCRIPTION
It needs to create resources before it can do that.

The previous PR #44 added a resource that is not valid, but because this repo doesn't run e2e-aws the blocking job didn't catch it.

I rolled back the image to create a new payload, and this removes the repo from the release payload by removing the labels on the docker files.  If service catalog is supposed to be in the payload, add e2e-aws before attempting to re-add it.