### PR TITLE
revert logging back to reporting pkg.VERSION

### DIFF
--- a/pkg/hyperkube/hyperkube.go
+++ b/pkg/hyperkube/hyperkube.go
@@ -189,7 +189,7 @@ RunAgain:
 
 	logs.InitLogs()
 	defer logs.FlushLogs()
-	klog.Infof("Service Catalog version %s (built %s)", version.Get().String(), version.Get().BuildDate)
+	klog.Infof("Service Catalog version %s (built %s)", pkg.VERSION, version.Get().BuildDate)
 	if !s.RespectsStopCh {
 		// For commands that do not respect the stopCh, we run them in a go
 		// routine and leave them running when stopCh is closed.


### PR DESCRIPTION
this fix got trampled on by the 0.1.42 updated in pr #50 

Report version format is 
`Service Catalog version v4.0.0-0.1.42+d79ee7d-dirty;Upstream:v0.1.42 (built 2019-03-20T16:52:23Z)`