### PR TITLE
Adding build support for archs other than amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/kubernetes-incubator/service-catalog
 COPY . .
-RUN make build
+RUN make build; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/kubernetes-incubator/service-catalog/_output/local/bin/linux/$(go env GOARCH)/service-catalog /tmp/build/;
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/kubernetes-incubator/service-catalog/_output/local/bin/linux/amd64/service-catalog /usr/bin/
+COPY --from=builder /tmp/build/service-catalog /usr/bin/
 COPY manifests /manifests/
 CMD ["/usr/bin/service-catalog"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,9 +1,11 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/kubernetes-incubator/service-catalog
 COPY . .
-RUN make build
+RUN make build; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/kubernetes-incubator/service-catalog/_output/local/bin/linux/$(go env GOARCH)/service-catalog /tmp/build/;
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/kubernetes-incubator/service-catalog/_output/local/bin/linux/amd64/service-catalog /usr/bin/
+COPY --from=builder /tmp/build/service-catalog /usr/bin/
 COPY manifests /manifests/
 CMD ["/usr/bin/service-catalog"]


### PR DESCRIPTION
This modifies the Dockerfile to add the build support for archs other than amd64.