### PR TITLE
Do not add protobuf serializer to accepted content-types

### DIFF
--- a/vendor/k8s.io/apimachinery/pkg/runtime/serializer/protobuf_extension.go
+++ b/vendor/k8s.io/apimachinery/pkg/runtime/serializer/protobuf_extension.go
@@ -44,5 +44,5 @@ func protobufSerializer(scheme *runtime.Scheme) (serializerType, bool) {
 }
 
 func init() {
-	serializerExtensions = append(serializerExtensions, protobufSerializer)
+	// serializerExtensions = append(serializerExtensions, protobufSerializer)
 }


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-incubator/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-incubator/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
Quick hack to prevent https://bugzilla.redhat.com/show_bug.cgi?id=1768820 , where namespaces couldn't terminate because the new metadata client used in 1.16 for namespace deletion requests both protobuf and JSON. Protobuf was listed as an accepted content type by the service catalog, but there are no protobuf serializers for the service catalog types, so it would just fail whenever the namespace deleter made those requests. This PR just stops the protobuf serializer from being added at all, which means the service catalog should properly fall back to JSON

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
