### PR TITLE
Remove CI repo enablement

### DIFF
--- a/images/service-catalog/Dockerfile
+++ b/images/service-catalog/Dockerfile
@@ -1,7 +1,7 @@
 FROM openshift/origin-source
 
 RUN INSTALL_PKGS="origin-service-catalog" && \
-    yum --enablerepo=origin-local-release install -y ${INSTALL_PKGS} && \
+    yum install -y ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     yum clean all
 


### PR DESCRIPTION
Urgently required to help us migrate to UBI8 for 4.6. Inclusion of this repo is causing https://github.com/openshift/release/pull/10888 to fail. 